### PR TITLE
Rename Databricks daily workflow for clearer purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It includes:
    - `/Users/dvervarcke/Documents/New project/sql/002_enrich_city_from_external_zip.sql`
 3. Deploy notebook and job:
    - Notebook path: `/Workspace/Users/rickoe@hotmail.com/taxi_dw/update_missing_cities`
-   - Job name: `taxi-dw-missing-city-refresh`
+   - Job name: `taxi-dw-daily-incremental-load-and-enrichment`
    - Job ID: `52643488824313`
 
 ## Scheduled Pipeline

--- a/docs/taxi_dw_runbook.md
+++ b/docs/taxi_dw_runbook.md
@@ -38,8 +38,8 @@ SELECT 'fact_taxi_rides', COUNT(*) FROM main.taxi_dw.fact_taxi_rides;
 - `state_code`
 - `dw_loaded_at`
 
-## Scheduled missing-city pipeline
-- Databricks job: `taxi-dw-missing-city-refresh`
+## Scheduled daily pipeline
+- Databricks job: `taxi-dw-daily-incremental-load-and-enrichment`
 - Job ID: `52643488824313`
 - Notebook paths:
   - `/Workspace/Users/rickoe@hotmail.com/taxi_dw/run_incremental_dw_load`

--- a/jobs/taxi_dw_missing_city_job.json
+++ b/jobs/taxi_dw_missing_city_job.json
@@ -1,5 +1,5 @@
 {
-  "name": "taxi-dw-missing-city-refresh",
+  "name": "taxi-dw-daily-incremental-load-and-enrichment",
   "max_concurrent_runs": 1,
   "schedule": {
     "quartz_cron_expression": "0 0 7 * * ?",


### PR DESCRIPTION
## Summary
- rename Databricks job to 
- update local job JSON and docs to match new job name

## Notes
- schedule remains daily at 07:00 America/Los_Angeles
- task chain remains: incremental load -> city enrichment