### PR TITLE
Add Databricks CI/CD for prod catalog deployment

### DIFF
--- a/.github/workflows/databricks-cicd.yml
+++ b/.github/workflows/databricks-cicd.yml
@@ -1,0 +1,53 @@
+name: Databricks CI/CD
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "databricks.yml"
+      - "pipelines/**"
+      - ".github/workflows/databricks-cicd.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "databricks.yml"
+      - "pipelines/**"
+      - ".github/workflows/databricks-cicd.yml"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Databricks CLI
+        uses: databricks/setup-cli@main
+
+      - name: Validate bundle (dev)
+        run: databricks bundle validate -t dev
+
+  deploy-prod:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Databricks CLI
+        uses: databricks/setup-cli@main
+
+      - name: Validate bundle (prod)
+        run: databricks bundle validate -t prod
+
+      - name: Deploy to Databricks prod target
+        run: databricks bundle deploy -t prod

--- a/.github/workflows/databricks-cicd.yml
+++ b/.github/workflows/databricks-cicd.yml
@@ -18,9 +18,6 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    env:
-      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,17 +25,33 @@ jobs:
       - name: Setup Databricks CLI
         uses: databricks/setup-cli@main
 
+      - name: Check Databricks credentials
+        id: creds
+        run: |
+          if [ -n "${{ secrets.DATABRICKS_HOST }}" ] && [ -n "${{ secrets.DATABRICKS_TOKEN }}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Validate bundle (dev)
+        if: steps.creds.outputs.available == 'true'
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
         run: databricks bundle validate -t dev
+
+      - name: Skip validate (missing secrets)
+        if: steps.creds.outputs.available != 'true'
+        run: |
+          echo "Skipping Databricks validation."
+          echo "Set repository secrets DATABRICKS_HOST and DATABRICKS_TOKEN to enable full CI validation."
 
   deploy-prod:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: validate
     runs-on: ubuntu-latest
     environment: production
-    env:
-      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,8 +59,21 @@ jobs:
       - name: Setup Databricks CLI
         uses: databricks/setup-cli@main
 
+      - name: Require Databricks credentials
+        run: |
+          if [ -z "${{ secrets.DATABRICKS_HOST }}" ] || [ -z "${{ secrets.DATABRICKS_TOKEN }}" ]; then
+            echo "Missing required secrets: DATABRICKS_HOST and/or DATABRICKS_TOKEN"
+            exit 1
+          fi
+
       - name: Validate bundle (prod)
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
         run: databricks bundle validate -t prod
 
       - name: Deploy to Databricks prod target
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
         run: databricks bundle deploy -t prod

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It includes:
 - Incremental star-schema SQL load (`fact_taxi_rides`, `dim_date`, `dim_zipcode`, `dim_city`)
 - External ZIP-to-city enrichment flow
 - Scheduled Databricks Workflow to refresh missing city mappings
+- CI/CD deployment to Databricks `prod` target via Databricks Asset Bundles
 
 ## Repository Structure
 
@@ -17,9 +18,13 @@ It includes:
 - `/Users/dvervarcke/Documents/New project/sql/002_enrich_city_from_external_zip.sql`
   - One-time city enrichment from external ZIP reference
 - `/Users/dvervarcke/Documents/New project/pipelines/update_missing_cities.py`
-  - Notebook code used by scheduled Databricks job
+  - Pipeline file used by scheduled Databricks job
 - `/Users/dvervarcke/Documents/New project/jobs/taxi_dw_missing_city_job.json`
   - Databricks job definition (serverless, scheduled)
+- `/Users/dvervarcke/Documents/New project/databricks.yml`
+  - Databricks Asset Bundle with `dev` and `prod` targets
+- `/Users/dvervarcke/Documents/New project/.github/workflows/databricks-cicd.yml`
+  - GitHub Actions workflow for validate + deploy
 - `/Users/dvervarcke/Documents/New project/data/zip_city_mapping.csv`
   - Generated external ZIP-city-state snapshot
 - `/Users/dvervarcke/Documents/New project/docs/taxi_dw_runbook.md`
@@ -50,6 +55,35 @@ It includes:
      - `/Users/rickoe@hotmail.com/taxi_dw/pipelines/update_missing_cities.py`
    - Job name: `taxi-dw-daily-incremental-load-and-enrichment`
    - Job ID: `52643488824313`
+
+## CI/CD to Prod Catalog
+
+The bundle deploys to the same Databricks workspace with different targets:
+
+- `dev` target:
+  - Catalog: `main`
+  - Schema: `taxi_dw`
+  - Job schedule: paused
+- `prod` target:
+  - Catalog: `prod`
+  - Schema: `taxi_dw`
+  - Job name: `taxi-dw-prod-daily-incremental-load-and-enrichment`
+  - Job schedule: daily 07:00 PT (unpaused)
+
+Required GitHub repository secrets:
+
+- `DATABRICKS_HOST` (example: `https://dbc-xxxx.cloud.databricks.com`)
+- `DATABRICKS_TOKEN` (PAT with permission to deploy jobs/files)
+
+Local bundle commands:
+
+```bash
+databricks bundle validate -t dev
+databricks bundle deploy -t dev
+
+databricks bundle validate -t prod
+databricks bundle deploy -t prod
+```
 
 ## Scheduled Pipeline
 

--- a/databricks.yml
+++ b/databricks.yml
@@ -1,0 +1,93 @@
+bundle:
+  name: taxi-dw
+
+variables:
+  catalog:
+    description: Target catalog for warehouse objects
+    default: main
+  schema:
+    description: Target schema/database for warehouse objects
+    default: taxi_dw
+  source_table:
+    description: Source trips table
+    default: samples.nyctaxi.trips
+
+workspace:
+  host: https://dbc-6cdd17f5-8c16.cloud.databricks.com
+
+resources:
+  jobs:
+    taxi_dw_daily_incremental:
+      name: taxi-dw-daily-incremental-load-and-enrichment
+      max_concurrent_runs: 1
+      environments:
+        - environment_key: default
+          spec:
+            client: "2"
+      tasks:
+        - task_key: run-incremental-dw-load
+          description: Incrementally merge new/changed source rows into taxi DW fact and dimensions.
+          spark_python_task:
+            python_file: ${workspace.file_path}/pipelines/run_incremental_dw_load.py
+            source: WORKSPACE
+            parameters:
+              - --catalog
+              - ${var.catalog}
+              - --schema
+              - ${var.schema}
+              - --source-table
+              - ${var.source_table}
+          environment_key: default
+          timeout_seconds: 0
+        - task_key: update-missing-cities
+          description: Refresh missing city names from external ZIP reference and incrementally upsert city/zipcode dimensions.
+          depends_on:
+            - task_key: run-incremental-dw-load
+          spark_python_task:
+            python_file: ${workspace.file_path}/pipelines/update_missing_cities.py
+            source: WORKSPACE
+            parameters:
+              - --catalog
+              - ${var.catalog}
+              - --schema
+              - ${var.schema}
+              - --source-table
+              - ${var.source_table}
+          environment_key: default
+          timeout_seconds: 0
+
+targets:
+  dev:
+    mode: development
+    default: true
+    workspace:
+      root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${bundle.target}
+    resources:
+      jobs:
+        taxi_dw_daily_incremental:
+          name: taxi-dw-dev-incremental-load-and-enrichment
+          schedule:
+            quartz_cron_expression: "0 0 7 * * ?"
+            timezone_id: America/Los_Angeles
+            pause_status: PAUSED
+    variables:
+      catalog: main
+      schema: taxi_dw
+      source_table: samples.nyctaxi.trips
+
+  prod:
+    mode: production
+    workspace:
+      root_path: /Workspace/Shared/.bundle/${bundle.name}/${bundle.target}
+    resources:
+      jobs:
+        taxi_dw_daily_incremental:
+          name: taxi-dw-prod-daily-incremental-load-and-enrichment
+          schedule:
+            quartz_cron_expression: "0 0 7 * * ?"
+            timezone_id: America/Los_Angeles
+            pause_status: UNPAUSED
+    variables:
+      catalog: prod
+      schema: taxi_dw
+      source_table: samples.nyctaxi.trips

--- a/docs/taxi_dw_runbook.md
+++ b/docs/taxi_dw_runbook.md
@@ -63,3 +63,11 @@ Manual run:
 ```bash
 databricks jobs run-now 52643488824313 --profile rickoe@hotmail.com
 ```
+
+## CI/CD deployment
+- Bundle config: `/Users/dvervarcke/Documents/New project/databricks.yml`
+- GitHub workflow: `/Users/dvervarcke/Documents/New project/.github/workflows/databricks-cicd.yml`
+- Prod target deploys to catalog `prod` and schema `taxi_dw` in the same Databricks workspace.
+- Workflow behavior:
+  - Pull request to `main`: `databricks bundle validate -t dev`
+  - Push to `main` / manual dispatch: validate + `databricks bundle deploy -t prod`

--- a/pipelines/update_missing_cities.py
+++ b/pipelines/update_missing_cities.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import urllib.error
 import urllib.request
@@ -10,9 +11,15 @@ from datetime import datetime, timezone
 
 from pyspark.sql import functions as F
 
-CATALOG = "main"
-SCHEMA = "taxi_dw"
-SOURCE_TABLE = "samples.nyctaxi.trips"
+parser = argparse.ArgumentParser()
+parser.add_argument("--catalog", default="main")
+parser.add_argument("--schema", default="taxi_dw")
+parser.add_argument("--source-table", default="samples.nyctaxi.trips")
+args, _ = parser.parse_known_args()
+
+CATALOG = args.catalog
+SCHEMA = args.schema
+SOURCE_TABLE = args.source_table
 REF_TABLE = f"{CATALOG}.{SCHEMA}.zip_city_reference"
 DIM_CITY_TABLE = f"{CATALOG}.{SCHEMA}.dim_city"
 DIM_ZIP_TABLE = f"{CATALOG}.{SCHEMA}.dim_zipcode"

--- a/pipelines/workspace_files/update_missing_cities.py
+++ b/pipelines/workspace_files/update_missing_cities.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import urllib.error
 import urllib.request
@@ -10,9 +11,15 @@ from datetime import datetime, timezone
 
 from pyspark.sql import functions as F
 
-CATALOG = "main"
-SCHEMA = "taxi_dw"
-SOURCE_TABLE = "samples.nyctaxi.trips"
+parser = argparse.ArgumentParser()
+parser.add_argument("--catalog", default="main")
+parser.add_argument("--schema", default="taxi_dw")
+parser.add_argument("--source-table", default="samples.nyctaxi.trips")
+args, _ = parser.parse_known_args()
+
+CATALOG = args.catalog
+SCHEMA = args.schema
+SOURCE_TABLE = args.source_table
 REF_TABLE = f"{CATALOG}.{SCHEMA}.zip_city_reference"
 DIM_CITY_TABLE = f"{CATALOG}.{SCHEMA}.dim_city"
 DIM_ZIP_TABLE = f"{CATALOG}.{SCHEMA}.dim_zipcode"


### PR DESCRIPTION
## Summary
- add Databricks Asset Bundle with dev/prod targets
- parameterize pipeline scripts for catalog/schema/source table
- add GitHub Actions workflow to validate and deploy prod on main
- document CI/CD and prod target behavior

## Deployment
- deployed bundle prod target to Databricks workspace
- created/updated prod job: taxi-dw-prod-daily-incremental-load-and-enrichment