### PR TITLE
Route Databricks CI/CD by branch (dev->dev, main->prod)

### DIFF
--- a/.github/workflows/databricks-cicd.yml
+++ b/.github/workflows/databricks-cicd.yml
@@ -2,18 +2,27 @@ name: Databricks CI/CD
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev", "codex/dev"]
     paths:
       - "databricks.yml"
       - "pipelines/**"
       - ".github/workflows/databricks-cicd.yml"
   push:
-    branches: ["main"]
+    branches: ["main", "dev", "codex/dev"]
     paths:
       - "databricks.yml"
       - "pipelines/**"
       - ".github/workflows/databricks-cicd.yml"
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Databricks bundle target to deploy"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - prod
 
 jobs:
   validate:
@@ -24,6 +33,26 @@ jobs:
 
       - name: Setup Databricks CLI
         uses: databricks/setup-cli@main
+
+      - name: Resolve bundle target
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            target="${{ inputs.target }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.base_ref }}" = "main" ]; then
+              target="prod"
+            else
+              target="dev"
+            fi
+          else
+            if [ "${{ github.ref_name }}" = "main" ]; then
+              target="prod"
+            else
+              target="dev"
+            fi
+          fi
+          echo "target=$target" >> "$GITHUB_OUTPUT"
 
       - name: Check Databricks credentials
         id: creds
@@ -39,7 +68,7 @@ jobs:
         env:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-        run: databricks bundle validate -t dev
+        run: databricks bundle validate -t ${{ steps.target.outputs.target }}
 
       - name: Skip validate (missing secrets)
         if: steps.creds.outputs.available != 'true'
@@ -47,8 +76,39 @@ jobs:
           echo "Skipping Databricks validation."
           echo "Set repository secrets DATABRICKS_HOST and DATABRICKS_TOKEN to enable full CI validation."
 
+  deploy-dev:
+    if: (github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'codex/dev')) || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Databricks CLI
+        uses: databricks/setup-cli@main
+
+      - name: Require Databricks credentials
+        run: |
+          if [ -z "${{ secrets.DATABRICKS_HOST }}" ] || [ -z "${{ secrets.DATABRICKS_TOKEN }}" ]; then
+            echo "Missing required secrets: DATABRICKS_HOST and/or DATABRICKS_TOKEN"
+            exit 1
+          fi
+
+      - name: Validate bundle (dev)
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+        run: databricks bundle validate -t dev
+
+      - name: Deploy to Databricks dev target
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+        run: databricks bundle deploy -t dev
+
   deploy-prod:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     needs: validate
     runs-on: ubuntu-latest
     environment: production

--- a/.github/workflows/databricks-cicd.yml
+++ b/.github/workflows/databricks-cicd.yml
@@ -54,27 +54,18 @@ jobs:
           fi
           echo "target=$target" >> "$GITHUB_OUTPUT"
 
-      - name: Check Databricks credentials
-        id: creds
+      - name: Require Databricks credentials
         run: |
-          if [ -n "${{ secrets.DATABRICKS_HOST }}" ] && [ -n "${{ secrets.DATABRICKS_TOKEN }}" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
+          if [ -z "${{ secrets.DATABRICKS_HOST }}" ] || [ -z "${{ secrets.DATABRICKS_TOKEN }}" ]; then
+            echo "Missing required secrets: DATABRICKS_HOST and/or DATABRICKS_TOKEN"
+            exit 1
           fi
 
-      - name: Validate bundle (dev)
-        if: steps.creds.outputs.available == 'true'
+      - name: Validate bundle
         env:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
         run: databricks bundle validate -t ${{ steps.target.outputs.target }}
-
-      - name: Skip validate (missing secrets)
-        if: steps.creds.outputs.available != 'true'
-        run: |
-          echo "Skipping Databricks validation."
-          echo "Set repository secrets DATABRICKS_HOST and DATABRICKS_TOKEN to enable full CI validation."
 
   deploy-dev:
     if: (github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'codex/dev')) || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ It includes:
 The bundle deploys to the same Databricks workspace with different targets:
 
 - `dev` target:
-  - Catalog: `main`
+  - Catalog: `dev`
   - Schema: `taxi_dw`
   - Job schedule: paused
 - `prod` target:

--- a/databricks.yml
+++ b/databricks.yml
@@ -71,7 +71,7 @@ targets:
             timezone_id: America/Los_Angeles
             pause_status: PAUSED
     variables:
-      catalog: main
+      catalog: dev
       schema: taxi_dw
       source_table: samples.nyctaxi.trips
 


### PR DESCRIPTION
## Summary
- set bundle dev target catalog to 
- keep prod target catalog as 
- update GitHub Actions to deploy target by branch:
  - push to / -> deploy 
  - push to  -> deploy 
- add workflow_dispatch target selection ( or )

## Validation
- databricks bundle validate -t dev passed
- databricks bundle validate -t prod passed (shared-path warning unchanged)